### PR TITLE
Response time fix

### DIFF
--- a/MIID/validator/forward.py
+++ b/MIID/validator/forward.py
@@ -102,7 +102,7 @@ async def dendrite_with_retries(dendrite: bt.dendrite, axons: list, synapse: Ide
         for i, response in enumerate(responses):
             round_trip = time.time() - send_time  # how long this miner took
             response_times[idx[i]] = round_trip
-            bt.logging.info(f"#########################################Response_time {i}: {round_trip}#########################################")
+            #bt.logging.info(f"#########################################Response {i}: {response}#########################################")
             #bt.logging.info(f"#########################################Response type: {type(response)}#########################################")
             
             if isinstance(response, dict):
@@ -261,6 +261,7 @@ async def forward(self):
         for idx_resp, response in enumerate(batch_responses):
             uid = batch_uids[idx_resp]
             response_time = batch_times[idx_resp] if batch_times[idx_resp] else None
+            bt.logging.info(f"#########################################Miner {idx_resp}: respones time {response_time}#########################################")
             if not hasattr(response, 'variations'):
                 bt.logging.warning(f"Miner {uid} returned response without 'variations' attribute.")
             elif response.variations is None:

--- a/MIID/validator/forward.py
+++ b/MIID/validator/forward.py
@@ -265,7 +265,7 @@ async def forward(self):
 
         for idx_resp, response in enumerate(batch_responses):
             uid = batch_uids[idx_resp]
-            response_time = batch_times[idx_resp] if batch_times[idx_resp] else None
+            response_time = batch_times[idx_resp] if batch_times[idx_resp] else 0.0
             bt.logging.info(f"#########################################Miner {idx_resp}: respones time {response_time}#########################################")
             # bt.logging.info(f"#########################################Miner {idx_resp}: respones time {response_time}#########################################")
             if not hasattr(response, 'variations'):

--- a/MIID/validator/forward.py
+++ b/MIID/validator/forward.py
@@ -266,7 +266,7 @@ async def forward(self):
         for idx_resp, response in enumerate(batch_responses):
             uid = batch_uids[idx_resp]
             response_time = batch_times[idx_resp] if batch_times[idx_resp] else 0.0
-            bt.logging.info(f"#########################################Miner {idx_resp}: respones time {response_time}#########################################")
+            bt.logging.info(f"######################################### Miner UID {uid}: response time {response_time:.2f}s #########################################")
             # bt.logging.info(f"#########################################Miner {idx_resp}: respones time {response_time}#########################################")
             if not hasattr(response, 'variations'):
                 bt.logging.warning(f"Miner {uid} returned response without 'variations' attribute.")

--- a/MIID/validator/forward.py
+++ b/MIID/validator/forward.py
@@ -100,7 +100,7 @@ async def dendrite_with_retries(dendrite: bt.dendrite, axons: list, synapse: Ide
             return None, None
     
     for attempt in range(cnt_attempts):
-        tasks = [timed_request(axon, synapse, deserialize, attempt) for axon in axons]
+        tasks = [timed_request(axon, synapse, deserialize, attempt) for axon in axons_for_retry]
         results = await asyncio.gather(*tasks)
         
         new_idx = []

--- a/MIID/validator/forward.py
+++ b/MIID/validator/forward.py
@@ -102,7 +102,7 @@ async def dendrite_with_retries(dendrite: bt.dendrite, axons: list, synapse: Ide
         for i, response in enumerate(responses):
             round_trip = time.time() - send_time  # how long this miner took
             response_times[idx[i]] = round_trip
-            #bt.logging.info(f"#########################################Response {i}: {response}#########################################")
+            bt.logging.info(f"#########################################Response_time {i}: {round_trip}#########################################")
             #bt.logging.info(f"#########################################Response type: {type(response)}#########################################")
             
             if isinstance(response, dict):

--- a/MIID/validator/forward.py
+++ b/MIID/validator/forward.py
@@ -93,6 +93,8 @@ async def dendrite_with_retries(dendrite: bt.dendrite, axons: list, synapse: Ide
         try:
             response = await dendrite([axon], synapse=synapse, deserialize=deserialize, timeout=timeout * (1 + attempt * 1.0))
             response_time = time.time() - start
+            if response[0] == {}:
+                response_time = 0.0
             return response[0], response_time
         except Exception:
             return None, None
@@ -107,11 +109,7 @@ async def dendrite_with_retries(dendrite: bt.dendrite, axons: list, synapse: Ide
         for i, (response, response_time) in enumerate(results):
             res[i] = response
             response_times[idx[i]] = response_time
-            bt.logging.info(f"#########################################Trying to find time is here#########################################")
-            bt.logging.info(f"#########################################Response {i}: {response}#########################################")
-            bt.logging.info(f"#########################################Response type: {type(response)}#########################################")
-            bt.logging.info(f"#########################################Miner {i}: respones time {response_time}#########################################")
-            
+        
             if isinstance(response, dict):
                 # Got the variations dictionary directly
                 complete_response = IdentitySynapse(
@@ -268,6 +266,7 @@ async def forward(self):
         for idx_resp, response in enumerate(batch_responses):
             uid = batch_uids[idx_resp]
             response_time = batch_times[idx_resp] if batch_times[idx_resp] else None
+            bt.logging.info(f"#########################################Miner {idx_resp}: respones time {response_time}#########################################")
             # bt.logging.info(f"#########################################Miner {idx_resp}: respones time {response_time}#########################################")
             if not hasattr(response, 'variations'):
                 bt.logging.warning(f"Miner {uid} returned response without 'variations' attribute.")

--- a/MIID/validator/forward.py
+++ b/MIID/validator/forward.py
@@ -102,8 +102,10 @@ async def dendrite_with_retries(dendrite: bt.dendrite, axons: list, synapse: Ide
         for i, response in enumerate(responses):
             round_trip = time.time() - send_time  # how long this miner took
             response_times[idx[i]] = round_trip
-            #bt.logging.info(f"#########################################Response {i}: {response}#########################################")
-            #bt.logging.info(f"#########################################Response type: {type(response)}#########################################")
+            bt.logging.info(f"#########################################Trying to find time is here#########################################")
+            bt.logging.info(f"#########################################Response {i}: {response}#########################################")
+            bt.logging.info(f"#########################################Response type: {type(response)}#########################################")
+            bt.logging.info(f"#########################################Miner {i}: respones time {round_trip}#########################################")
             
             if isinstance(response, dict):
                 # Got the variations dictionary directly
@@ -261,7 +263,7 @@ async def forward(self):
         for idx_resp, response in enumerate(batch_responses):
             uid = batch_uids[idx_resp]
             response_time = batch_times[idx_resp] if batch_times[idx_resp] else None
-            bt.logging.info(f"#########################################Miner {idx_resp}: respones time {response_time}#########################################")
+            # bt.logging.info(f"#########################################Miner {idx_resp}: respones time {response_time}#########################################")
             if not hasattr(response, 'variations'):
                 bt.logging.warning(f"Miner {uid} returned response without 'variations' attribute.")
             elif response.variations is None:


### PR DESCRIPTION
This changes the way we request the miners. The way we were doing it before did not allow allow the validators collect the information of every single miner. This changed it so that we can.