### PR TITLE
no sql, 1.2 rule

### DIFF
--- a/MIID/validator/query_generator.py
+++ b/MIID/validator/query_generator.py
@@ -852,7 +852,7 @@ class QueryGenerator:
         1. The query MUST use {{name}} as a placeholder for the target name.
         2. Format as a natural language request that explicitly states all requirements.
         3. Include both the similarity requirements (phonetic and orthographic) AND the rule-based transformation requirements in the query.
-        4. Do not write SQL queries
+        4. Do not write any SQL queries or any code. Return text only.
         
         CRITICAL: Return ONLY the query template text. Do not include any explanations, analysis, or commentary about the query. Do not say "this query meets requirements" or similar phrases. Just return the actual query template that miners will receive.
         

--- a/MIID/validator/query_generator.py
+++ b/MIID/validator/query_generator.py
@@ -852,6 +852,7 @@ class QueryGenerator:
         1. The query MUST use {{name}} as a placeholder for the target name.
         2. Format as a natural language request that explicitly states all requirements.
         3. Include both the similarity requirements (phonetic and orthographic) AND the rule-based transformation requirements in the query.
+        4. Do not write SQL queries
         
         CRITICAL: Return ONLY the query template text. Do not include any explanations, analysis, or commentary about the query. Do not say "this query meets requirements" or similar phrases. Just return the actual query template that miners will receive.
         

--- a/MIID/validator/reward.py
+++ b/MIID/validator/reward.py
@@ -909,7 +909,7 @@ def get_name_variation_rewards(
         # Penalty for too many variations per name
         for name, vars_list in variations.items():
             if variation_count > 0:
-                allowed_with_grace = int(variation_count * 1.6)  # 60% grace, rounded down
+                allowed_with_grace = int(variation_count * 1.2)  # 60% grace, rounded down
                 if len(vars_list) > allowed_with_grace:
                     too_many = len(vars_list) - allowed_with_grace
                     penalty_too_many = too_many * 0.05  # 5% per extra

--- a/MIID/validator/reward.py
+++ b/MIID/validator/reward.py
@@ -909,7 +909,7 @@ def get_name_variation_rewards(
         # Penalty for too many variations per name
         for name, vars_list in variations.items():
             if variation_count > 0:
-                allowed_with_grace = int(variation_count * 1.2)  # 60% grace, rounded down
+                allowed_with_grace = int(variation_count * 1.2)  # 20% grace, rounded down
                 if len(vars_list) > allowed_with_grace:
                     too_many = len(vars_list) - allowed_with_grace
                     penalty_too_many = too_many * 0.05  # 5% per extra


### PR DESCRIPTION
We change the rule base to be back to 1.2. We also added a section in the query generator prompts to make sure there is no sql prompts.